### PR TITLE
Full conformer workflow

### DIFF
--- a/aiidalab_ispg/process.py
+++ b/aiidalab_ispg/process.py
@@ -9,9 +9,9 @@ from aiida.cmdline.utils.query.calculation import CalculationQueryBuilder
 from aiida.orm import load_node
 from aiida.plugins import DataFactory
 
-StructureData = DataFactory('structure')
+StructureData = DataFactory("structure")
 
-WORKCHAIN_LABEL = "OrcaWignerSpectrumWorkChain"
+WORKCHAIN_LABEL = "AtmospecWorkChain"
 
 
 class WorkChainSelector(ipw.HBox):

--- a/aiidalab_ispg/spectrum.py
+++ b/aiidalab_ispg/spectrum.py
@@ -52,7 +52,7 @@ class Spectrum(object):
     AUtoCm = 8.478354e-30
     COEFF = (
         constants.pi
-        * AUtoCm ** 2
+        * AUtoCm**2
         * 1e4
         / (3 * scipy.constants.hbar * scipy.constants.epsilon_0 * scipy.constants.c)
     )
@@ -140,7 +140,7 @@ class Spectrum(object):
         unit_factor = self.COEFF_NEW
         for exc_energy, osc_strength in zip(energies, self.osc_strengths):
             prefactor = normalization_factor * unit_factor * osc_strength
-            y += prefactor * np.exp(-((x - exc_energy) ** 2) / 2 / sigma ** 2)
+            y += prefactor * np.exp(-((x - exc_energy) ** 2) / 2 / sigma**2)
 
         if x_unit.lower() == "nm":
             x, y = self._convert_to_nanometers(x, y)
@@ -171,7 +171,7 @@ class Spectrum(object):
 
         for exc_energy, osc_strength in zip(energies, self.osc_strengths):
             prefactor = normalization_factor * unit_factor * osc_strength
-            y += prefactor / ((x - exc_energy) ** 2 + (tau ** 2) / 4)
+            y += prefactor / ((x - exc_energy) ** 2 + (tau**2) / 4)
 
         if x_unit.lower() == "nm":
             x, y = self._convert_to_nanometers(x, y)
@@ -328,8 +328,8 @@ class SpectrumWidget(ipw.VBox):
         if not self._validate_transitions():
             self.hide_line(self.THEORY_SPEC_LABEL)
             return
-        # TODO: Remove this try/except, and figure out a better
-        # way to pass number of samples maybe.
+        # TODO: Need to fix this normalization now that we have multiple conformers!
+        # We should have explicit metadata about number of conformers, number of states, number of geometries
         try:
             nsample = self.transitions[-1]["geom_index"] + 1
         except KeyError:
@@ -431,6 +431,7 @@ class SpectrumWidget(ipw.VBox):
     def _observe_smiles(self, change):
         self._find_experimental_spectrum(change["new"])
 
+    # TODO: Make sure that this does not slow us down too much
     def _find_experimental_spectrum(self, smiles):
         """Find an experimental spectrum for a given SMILES
         and plot it if it is available in our DB"""

--- a/aiidalab_ispg/steps.py
+++ b/aiidalab_ispg/steps.py
@@ -31,7 +31,7 @@ from aiidalab_ispg.widgets import NodeViewWidget, ResourceSelectionWidget
 from aiidalab_ispg.widgets import QMSelectionWidget
 
 try:
-    from aiidalab_atmospec_workchain import OrcaWignerSpectrumWorkChain
+    from aiidalab_atmospec_workchain import AtmospecWorkChain
 except ImportError:
     # TODO: Can we do something better than print here?
     print("ERROR: Could not find aiidalab_atmospec_workchain module!")
@@ -414,7 +414,7 @@ class SubmitOrcaAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
 
         builder_parameters = self.builder_parameters.copy()
 
-        builder = OrcaWignerSpectrumWorkChain.get_builder()
+        builder = AtmospecWorkChain.get_builder()
 
         orca_code = self.codes_selector.orca.selected_code
         builder.code = orca_code

--- a/workflow_workspace.ipynb
+++ b/workflow_workspace.ipynb
@@ -1,0 +1,255 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2cfaa17e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%aiida"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d40237d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from aiidalab_atmospec_workchain import OrcaWignerSpectrumWorkChain\n",
+    "from aiida.engine import WorkChain, calcfunction\n",
+    "from aiida.engine import submit, run, append_, ToContext, if_\n",
+    "\n",
+    "StructureData = DataFactory(\"structure\")\n",
+    "TrajectoryData = DataFactory(\"array.trajectory\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e019ab5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Unfortunately, variadic arguments are not supported in calcfunctions\n",
+    "# We'll need to use a full workchain with dynamic namespace for this\n",
+    "\n",
+    "#@calcfunction\n",
+    "#def concatenate_outputs(*arg):\n",
+    "#    pass\n",
+    "\n",
+    "class AtmospecWorkChain(WorkChain):\n",
+    "    \"\"\"The top-level ATMOSPEC workchain\"\"\"\n",
+    "    \n",
+    "    @classmethod\n",
+    "    def define(cls, spec):\n",
+    "        super().define(spec)\n",
+    "        spec.expose_inputs(OrcaWignerSpectrumWorkChain, exclude=[\"structure\"])\n",
+    "        spec.input(\"structure\", valid_type=(StructureData, TrajectoryData))\n",
+    "        \n",
+    "        spec.expose_outputs(OrcaWignerSpectrumWorkChain, exclude=[\"relaxed_structure\"])\n",
+    "        \n",
+    "        spec.outline(\n",
+    "            cls.setup,\n",
+    "            cls.launch,\n",
+    "            cls.collect,\n",
+    "        )\n",
+    "        \n",
+    "        spec.output(\"orca_outputs\", valid_type=List, required=False, help=\"Outputs from all conformers\")\n",
+    "        spec.output(\n",
+    "            \"relaxed_structures\", \n",
+    "            valid_type=TrajectoryData,\n",
+    "            required=False,\n",
+    "            help=\"Minimized structures of all conformers\"\n",
+    "        )\n",
+    "        \n",
+    "        # Very generic error now\n",
+    "        spec.exit_code(410, \"CONFORMER_ERROR\", \"Conformer spectrum generation failed\")\n",
+    "        \n",
+    "    def setup(self):\n",
+    "        pass\n",
+    "    \n",
+    "    def collect(self):\n",
+    "        # For single conformer\n",
+    "        if isinstance(self.inputs.structure, StructureData):\n",
+    "            if not self.ctx.conf.is_finished_ok:\n",
+    "                return self.exit_codes.CONFORMER_ERROR\n",
+    "            self.out_many(self.exposed_outputs(self.ctx.conf, OrcaWignerSpectrumWorkChain))\n",
+    "            return\n",
+    "        \n",
+    "        for wc in self.ctx.confs:\n",
+    "            # TODO: Specialize erros. Can we expose errors from child workflows?\n",
+    "            if not wc.is_finished_ok:\n",
+    "                return self.exit_codes.CONFORMER_ERROR\n",
+    "          \n",
+    "        # TODO: Collect output dictionaries\n",
+    "        \n",
+    "        # TODO: Include energies and boltzmann weights in TrajectoryData for optimized structures\n",
+    "        if self.inputs.optimize:\n",
+    "            structs = [workchain.outputs.relaxed_structure for workchain in self.ctx.confs]\n",
+    "            # TODO: Preserve provenance via ConcatenateOutputs workchain\n",
+    "            self.out(\"relaxed_structures\", TrajectoryData(structurelist=structs).store())\n",
+    "        \n",
+    "        self.out_many(self.exposed_outputs(self.ctx.confs[0], OrcaWignerSpectrumWorkChain))\n",
+    "\n",
+    "    def launch(self):\n",
+    "        inputs = self.exposed_inputs(\n",
+    "            OrcaWignerSpectrumWorkChain, agglomerate=False\n",
+    "        )\n",
+    "        # Single conformer\n",
+    "        # TODO: Test this!\n",
+    "        if isinstance(self.inputs.structure, StructureData):\n",
+    "            self.report(\"Launching ATMOSPEC for 1 conformer\")\n",
+    "            inputs.structure = self.inputs.structure\n",
+    "            return ToContext(conf=self.submit(OrcaWignerSpectrumWorkChain, **inputs))\n",
+    "        \n",
+    "        self.report(f\"Launching ATMOSPEC for {len(self.inputs.structure.get_stepids())} conformers\")\n",
+    "        for conf_id in self.inputs.structure.get_stepids():\n",
+    "            inputs.structure = self.inputs.structure.get_step_structure(conf_id)\n",
+    "            workflow = self.submit(OrcaWignerSpectrumWorkChain, **inputs)\n",
+    "            #workflow.label = 'conformer-wigner-spectrum'\n",
+    "            self.to_context(confs=append_(workflow))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85ae0094",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "builder = AtmospecWorkChain.get_builder()\n",
+    "old_workchain = load_node(pk=1218)\n",
+    "builder[\"structure\"] = old_workchain.inputs.structure\n",
+    "for input in old_workchain.inputs:\n",
+    "    if input != 'structure':\n",
+    "        builder[input] = old_workchain.inputs[input]\n",
+    "\n",
+    "builder.optimize = Bool(True)\n",
+    "builder.opt.clean_workdir = Bool(True)\n",
+    "builder.exc.clean_workdir = Bool(True)\n",
+    "builder.opt.orca.metadata.options.resources = {'tot_num_mpiprocs': 1}\n",
+    "builder.exc.orca.metadata.options.resources = {'tot_num_mpiprocs': 1}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01736449",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "builder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57378d6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proc = run(builder)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d544392",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proc = load_node(pk=1456)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54c37290",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for output in proc.outputs:\n",
+    "    print(output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0547ef41",
+   "metadata": {},
+   "source": [
+    "# Now test more than one conformer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b987119c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "builder = AtmospecWorkChain.get_builder()\n",
+    "old_workchain = load_node(pk=226)\n",
+    "builder.structure = old_workchain.inputs.structure\n",
+    "for input in old_workchain.inputs:\n",
+    "    if input != 'structure':\n",
+    "        builder[input] = old_workchain.inputs[input]\n",
+    "        \n",
+    "# Patch the inputs to reduct comp cost\n",
+    "builder.nwigner = 2\n",
+    "\n",
+    "params = builder.opt.orca.parameters.get_dict()\n",
+    "params['input_keywords'] = ['sto-3g', 'pbe', 'Opt', 'AnFreq']\n",
+    "builder.opt.orca.parameters = Dict(dict=params)\n",
+    "\n",
+    "params = builder.exc.orca.parameters.get_dict()\n",
+    "params['input_keywords'] = ['sto-3g', 'pbe']\n",
+    "builder.exc.orca.parameters = Dict(dict=params)\n",
+    "\n",
+    "# Not sure why this is not already included\n",
+    "builder.opt.orca.metadata.options.resources = {'tot_num_mpiprocs': 1}\n",
+    "builder.exc.orca.metadata.options.resources = {'tot_num_mpiprocs': 1}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21223b4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proc = run(builder)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c31cdfc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/workflow_workspace.ipynb
+++ b/workflow_workspace.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2cfaa17e",
+   "id": "a476df62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,32 +13,71 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d40237d6",
+   "id": "81c5299e",
    "metadata": {},
    "outputs": [],
    "source": [
     "from aiidalab_atmospec_workchain import OrcaWignerSpectrumWorkChain\n",
     "from aiida.engine import WorkChain, calcfunction\n",
     "from aiida.engine import submit, run, append_, ToContext, if_\n",
+    "from aiida.engine import run_get_node, run_get_pk\n",
     "\n",
     "StructureData = DataFactory(\"structure\")\n",
+    "Dict = DataFactory(\"dict\")\n",
     "TrajectoryData = DataFactory(\"array.trajectory\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e019ab5f",
+   "id": "c38c3323",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Unfortunately, variadic arguments are not supported in calcfunctions\n",
-    "# We'll need to use a full workchain with dynamic namespace for this\n",
+    "# https://github.com/aiidateam/aiida-core/blob/2c183fc4486e00f3348a1b66cdcd6d9fbfd563f0/.github/system_tests/workchains.py#L182\n",
     "\n",
-    "#@calcfunction\n",
-    "#def concatenate_outputs(*arg):\n",
-    "#    pass\n",
-    "\n",
+    "# General WorkChain for combining all inputs from a dynamic namespace 'ns'\n",
+    "# into a single List.\n",
+    "# Used to combine outputs from several subworkflows into one output\n",
+    "# It should be launched via run() instead of submit()\n",
+    "class CombineInputsToList(WorkChain):\n",
+    "    \n",
+    "    @classmethod\n",
+    "    def define(cls, spec):\n",
+    "        super().define(spec)\n",
+    "        spec.input_namespace(\"ns\", dynamic=True)\n",
+    "        spec.output(\"output\", valid_type=List)\n",
+    "        spec.outline(cls.combine)\n",
+    "        \n",
+    "    def combine(self):\n",
+    "        #input_list = [self.inputs.ns[k] for k in self.inputs.ns]\n",
+    "        input_list = [self.inputs.ns[k].get_dict() if isinstance(self.inputs.ns[k], Dict) else self.inputs.ns[k] for k in self.inputs.ns]\n",
+    "        self.out('output', List(list=input_list).store())\n",
+    "        \n",
+    "        \n",
+    "class CombineStructuresToTrajectoryData(WorkChain):\n",
+    "    \n",
+    "    @classmethod\n",
+    "    def define(cls, spec):\n",
+    "        super().define(spec)\n",
+    "        # TODO: Maybe allow other types other than StructureData?\n",
+    "        # Not sure what are the requirements for TrajectoryData\n",
+    "        spec.input_namespace(\"structures\", dynamic=True, valid_type=StructureData)\n",
+    "        spec.output(\"trajectory\", valid_type=TrajectoryData)\n",
+    "        spec.outline(cls.combine)\n",
+    "        \n",
+    "    def combine(self):\n",
+    "        structurelist = [self.inputs.structures[k] for k in self.inputs.structures]\n",
+    "        self.out('trajectory', TrajectoryData(structurelist=structurelist).store())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9dd0be6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "class AtmospecWorkChain(WorkChain):\n",
     "    \"\"\"The top-level ATMOSPEC workchain\"\"\"\n",
     "    \n",
@@ -48,50 +87,31 @@
     "        spec.expose_inputs(OrcaWignerSpectrumWorkChain, exclude=[\"structure\"])\n",
     "        spec.input(\"structure\", valid_type=(StructureData, TrajectoryData))\n",
     "        \n",
+    "        # TODO: Remove this\n",
     "        spec.expose_outputs(OrcaWignerSpectrumWorkChain, exclude=[\"relaxed_structure\"])\n",
-    "        \n",
-    "        spec.outline(\n",
-    "            cls.setup,\n",
-    "            cls.launch,\n",
-    "            cls.collect,\n",
+    "\n",
+    "        spec.output(\n",
+    "            'spectrum_data',\n",
+    "            valid_type=List,\n",
+    "            required=True,\n",
+    "            help=\"All data necessary to construct spectrum in SpectrumWidget\"\n",
     "        )\n",
-    "        \n",
-    "        spec.output(\"orca_outputs\", valid_type=List, required=False, help=\"Outputs from all conformers\")\n",
+    "           \n",
     "        spec.output(\n",
     "            \"relaxed_structures\", \n",
     "            valid_type=TrajectoryData,\n",
     "            required=False,\n",
     "            help=\"Minimized structures of all conformers\"\n",
     "        )\n",
+    "\n",
+    "        spec.outline(\n",
+    "            cls.launch,\n",
+    "            cls.collect,\n",
+    "        )\n",
     "        \n",
     "        # Very generic error now\n",
     "        spec.exit_code(410, \"CONFORMER_ERROR\", \"Conformer spectrum generation failed\")\n",
     "        \n",
-    "    def setup(self):\n",
-    "        pass\n",
-    "    \n",
-    "    def collect(self):\n",
-    "        # For single conformer\n",
-    "        if isinstance(self.inputs.structure, StructureData):\n",
-    "            if not self.ctx.conf.is_finished_ok:\n",
-    "                return self.exit_codes.CONFORMER_ERROR\n",
-    "            self.out_many(self.exposed_outputs(self.ctx.conf, OrcaWignerSpectrumWorkChain))\n",
-    "            return\n",
-    "        \n",
-    "        for wc in self.ctx.confs:\n",
-    "            # TODO: Specialize erros. Can we expose errors from child workflows?\n",
-    "            if not wc.is_finished_ok:\n",
-    "                return self.exit_codes.CONFORMER_ERROR\n",
-    "          \n",
-    "        # TODO: Collect output dictionaries\n",
-    "        \n",
-    "        # TODO: Include energies and boltzmann weights in TrajectoryData for optimized structures\n",
-    "        if self.inputs.optimize:\n",
-    "            structs = [workchain.outputs.relaxed_structure for workchain in self.ctx.confs]\n",
-    "            # TODO: Preserve provenance via ConcatenateOutputs workchain\n",
-    "            self.out(\"relaxed_structures\", TrajectoryData(structurelist=structs).store())\n",
-    "        \n",
-    "        self.out_many(self.exposed_outputs(self.ctx.confs[0], OrcaWignerSpectrumWorkChain))\n",
     "\n",
     "    def launch(self):\n",
     "        inputs = self.exposed_inputs(\n",
@@ -109,13 +129,41 @@
     "            inputs.structure = self.inputs.structure.get_step_structure(conf_id)\n",
     "            workflow = self.submit(OrcaWignerSpectrumWorkChain, **inputs)\n",
     "            #workflow.label = 'conformer-wigner-spectrum'\n",
-    "            self.to_context(confs=append_(workflow))"
+    "            self.to_context(confs=append_(workflow))\n",
+    "    \n",
+    "    def collect(self):\n",
+    "        # For single conformer\n",
+    "        if isinstance(self.inputs.structure, StructureData):\n",
+    "            if not self.ctx.conf.is_finished_ok:\n",
+    "                return self.exit_codes.CONFORMER_ERROR\n",
+    "            self.out_many(self.exposed_outputs(self.ctx.conf, OrcaWignerSpectrumWorkChain))\n",
+    "            return\n",
+    "       \n",
+    "        # Check for errors\n",
+    "        for wc in self.ctx.confs:\n",
+    "            # TODO: Specialize erros. Can we expose errors from child workflows?\n",
+    "            if not wc.is_finished_ok:\n",
+    "                return self.exit_codes.CONFORMER_ERROR\n",
+    "        \n",
+    "        # Combine all spectra data\n",
+    "        data = {str(i): wc.outputs.wigner_tddft for i, wc in enumerate(self.ctx.confs)}\n",
+    "        all_results = run(CombineInputsToList, ns=data)\n",
+    "        self.out('spectrum_data', all_results['output'])\n",
+    "        \n",
+    "        # Combine all optimized geometries into single TrajectoryData\n",
+    "        # TODO: Include energies and boltzmann weights in TrajectoryData for optimized structures\n",
+    "        if self.inputs.optimize:\n",
+    "            relaxed_structures = {str(i): wc.outputs.relaxed_structure for i, wc in enumerate(self.ctx.confs)}\n",
+    "            output = run(CombineStructuresToTrajectoryData, structures=relaxed_structures)\n",
+    "            self.out(\"relaxed_structures\", output['trajectory'])\n",
+    "        \n",
+    "        self.out_many(self.exposed_outputs(self.ctx.confs[0], OrcaWignerSpectrumWorkChain))\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85ae0094",
+   "id": "ac587d51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01736449",
+   "id": "b3ef2cb9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,37 +194,38 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57378d6d",
+   "id": "ce7c885a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "proc = run(builder)"
+    "run(builder)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d544392",
+   "id": "4264acc8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "proc = load_node(pk=1456)"
+    "proc = load_node(pk=2023)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54c37290",
+   "id": "433801a8",
    "metadata": {},
    "outputs": [],
    "source": [
     "for output in proc.outputs:\n",
-    "    print(output)"
+    "    print(output)\n",
+    "proc.outputs.spectrum_data"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0547ef41",
+   "id": "25c6e576",
    "metadata": {},
    "source": [
     "# Now test more than one conformer"
@@ -185,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b987119c",
+   "id": "2e3136ae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,23 +258,150 @@
     "\n",
     "# Not sure why this is not already included\n",
     "builder.opt.orca.metadata.options.resources = {'tot_num_mpiprocs': 1}\n",
-    "builder.exc.orca.metadata.options.resources = {'tot_num_mpiprocs': 1}"
+    "builder.exc.orca.metadata.options.resources = {'tot_num_mpiprocs': 1}\n",
+    "builder.opt.clean_workdir = Bool(True)\n",
+    "builder.exc.clean_workdir = Bool(True)\n",
+    "builder"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21223b4a",
+   "id": "a7611a29",
    "metadata": {},
    "outputs": [],
    "source": [
-    "proc = run(builder)"
+    "output = run(builder)\n",
+    "output"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3c31cdfc",
+   "id": "011489fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = Int(1).store()\n",
+    "y = Int(2).store()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dfd7b891",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "struct = load_node(pk=1824)\n",
+    "l = [x, y, struct]\n",
+    "# This doesn't work\n",
+    "inputs = {str(i): val for i, val in enumerate(l)}\n",
+    "#run(CombineInputsToList, ns=inputs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30c6acaa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "065f69de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "l = [struct, struct]\n",
+    "inputs = {str(i): val for i, val in enumerate(l)}\n",
+    "traj = run(CombineStructuresToTrajectoryData, structures=inputs)\n",
+    "traj"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85008323",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(traj['trajectory'].get_stepids())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f00e88d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "l = [List(list=[1, 2]), List(list=[2, 3])]\n",
+    "inputs = {str(i): val for i, val in enumerate(l)}\n",
+    "run(CombineInputsToList, ns=inputs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0b62c26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "l = [Dict(dict={\"1\": 2}), Dict(dict={\"1\": 2})]\n",
+    "inputs = {str(i): val for i, val in enumerate(l)}\n",
+    "run(CombineInputsToList, ns=inputs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8590abfe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "l[0].get_dict()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cce310f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ConcatDictsToList(WorkChain):\n",
+    "    \n",
+    "    @classmethod\n",
+    "    def define(cls, spec):\n",
+    "        super().define(spec)\n",
+    "        spec.input_namespace(\"ns\", dynamic=True)\n",
+    "        spec.output(\"output\", valid_type=List)\n",
+    "        spec.outline(cls.combine)\n",
+    "        \n",
+    "    def combine(self):\n",
+    "        input_list = [self.inputs.ns[k].get_dict() for k in self.inputs.ns]\n",
+    "        self.out('output', List(list=input_list).store())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "255b2bc4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(ConcatDictsToList, ns=inputs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "710eb67c",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Compute all conformers, and assemble the Boltzmann-weighted spectrum. Closes #9 

TODOs: (some of these are probably for future PRs)

- [x] Collect Wigner dicts from All conformers to a single list
- [ ] Include energies and Boltzmann weights in relaxed_structures output
- [ ] Include Boltzmann weights in the initial structures optimized with xtb
- [ ] Display Boltzmann weights in TrajectoryDataViewer
- [ ] Figure out a new format for passing TDDFT data from individual conformers to the SpectrumWidget (probably just a list of what we are passing now + energies and Boltzmann weights)
- [ ] Hookup SpectrumWidget to the new format and calculate Boltzmann-wighted spectra
- [ ] FUTURE: Conformer selector to display conformer-specific spectra

