### PR TITLE
Load spectrum before loading the process tree

### DIFF
--- a/aiidalab_ispg/steps.py
+++ b/aiidalab_ispg/steps.py
@@ -526,7 +526,7 @@ class ViewAtmospecAppWorkChainStatusAndResultsStep(ipw.VBox, WizardAppWidgetStep
 
         # Setup process monitor
         self.process_monitor = ProcessMonitor(
-            timeout=0.1,
+            timeout=0.5,
             callbacks=[
                 self.process_tree.update,
                 self._update_state,
@@ -575,7 +575,7 @@ class ViewSpectrumStep(ipw.VBox, WizardAppWidgetStep):
     def __init__(self, **kwargs):
         # Setup process monitor
         self.process_monitor = ProcessMonitor(
-            timeout=0.1,
+            timeout=0.5,
             callbacks=[
                 self._show_spectrum,
                 self._update_state,

--- a/aiidalab_ispg/steps.py
+++ b/aiidalab_ispg/steps.py
@@ -659,4 +659,6 @@ class ViewSpectrumStep(ipw.VBox, WizardAppWidgetStep):
 
     @traitlets.observe("process")
     def _observe_process(self, change):
+        if change["new"] == change["old"]:
+            return
         self._update_state()

--- a/atmospec.ipynb
+++ b/atmospec.ipynb
@@ -526,6 +526,7 @@
     "                structure_manager_widget.input_structure = process.inputs.structure\n",
     "                structure_selection_step.structure = process.inputs.structure\n",
     "                structure_selection_step.confirmed_structure = process.inputs.structure\n",
+    "                view_spectrum_step.process = process\n",
     "                submit_atmospec_work_chain_step.process = process\n",
     "\n",
     "work_chain_selector.observe(_observe_process_selection, 'value')    \n",
@@ -543,13 +544,6 @@
     "\n",
     "display(welcome_message, app_with_work_chain_selector,footer)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import time
-import pytest
 
 from selenium.webdriver.common.by import By
 
@@ -17,7 +16,6 @@ def test_atmospec_app_init(selenium, url):
     selenium.get_screenshot_as_file("screenshots/atmospec-app.png")
 
 
-@pytest.mark.skip(reason="Waiting for new aiidalab-docker-stack image")
 def test_atmospec_generate_mol_from_smiles(selenium, url):
     selenium.get(url("apps/apps/aiidalab-ispg/atmospec.ipynb"))
     # selenium.set_window_size(1920, 1000)


### PR DESCRIPTION
We load the spectrum first, then we load the tree. We don't really speed up loading the tree (it's not clear how or if it can be sped up). In the end what we probably want to do it to only load the tree on demand (and display a loading bar while it happens).

A step towards #46 