### PR TITLE
Support OpenMPI parallelization of ORCA

### DIFF
--- a/aiidalab_ispg/widgets.py
+++ b/aiidalab_ispg/widgets.py
@@ -241,7 +241,7 @@ class ResourceSelectionWidget(ipw.VBox):
         """<div style="line-height:120%; padding-top:0px">
         <p style="padding-bottom:10px">
         Specify the number of MPI tasks for this calculation.
-        (Currently ignored).
+        (used only for optimization jobs with ORCA).
         </p></div>"""
     )
 

--- a/post_install
+++ b/post_install
@@ -12,6 +12,7 @@
 ORCA_PATH=/opt/orca
 
 function create_orca_code() {
+  # NOTE: We append LD_LIBRARY path since we install OpenMPI via conda in ATMOSPEC Docker image
   computer_name=$1
   code_name=orca
   verdi code show ${code_name}@${computer_name} 2>/dev/null || \
@@ -22,7 +23,7 @@ function create_orca_code() {
     --input-plugin ${code_name}.${code_name} \
     --computer ${computer_name} \
     --remote-abs-path ${ORCA_PATH}/orca \
-    --prepend-text "export PATH=${ORCA_PATH}:\$PATH"
+    --prepend-text "export PATH=${ORCA_PATH}:\$PATH;export LD_LIBRARY_PATH=/opt/conda/lib:\$LD_LIBRARY_PATH"
 }
 
 # Create orca code node on computer localhost,


### PR DESCRIPTION
Contingent upon corresponding PR https://github.com/danielhollas/aiidalab-ispg-docker-stack/pull/13
but changes here should be backwards compatible.

Importantly, `withmpi` must be set to False, because orca binary mustn't be run via mpirun, it uses mpirun internally.